### PR TITLE
Update how-to-login.md

### DIFF
--- a/unit-1-intro-to-the-admin-backend/how-to-login.md
+++ b/unit-1-intro-to-the-admin-backend/how-to-login.md
@@ -1,45 +1,26 @@
-# How to login to GovCMS
+# How to log in to a GovCMS environment
 
 {% embed url="https://vimeo.com/469210192/f8b616dd59" %}
 
-To get to the login screen of most GovCMS sites, simply type the site’s URL with **/user** on the end. \(For many government sites this won't work unless you’re on the internal network.\) For example:
+To get to the **Login screen** of most GovCMS sites, type the site’s URL and add **/user** on the end. \(For many government sites this won't work unless you’re on the internal network.\) For example:
 
 * [https://www.salsadigital.com.au/](https://www.salsadigital.com.au/user)[**user**](https://www.salsadigital.com.au/user)
-* [http://govcms.gov.au/](http://govcms.gov.au/user)[**user**](http://govcms.gov.au/user)
 
-If your training environment is hosted in the GovCMS cluster \(hosted by Amazee.io\), it’s protected against public access by _Shield_ authentication, which means you’ll see a popup window with the username and password fields.
 
-For this training course, every trainee is provided with an individual environment. To separate environments, we preconfigured individual URLs per environment. Each trainee should use their _Individual Environment ID_. Refer to the slide \(or the whiteboard\) for the environment URL.
+## Shield protection
+Your environment may be protected by _Shield_ authentication, which means you’ll see a popup window with the username and password fields. You need to enter the Shield **username** and **password** to get to the **Login screen**. 
 
-![](../.gitbook/assets/3%20%282%29.png)
+**Note** The Shield username and password are distinct from your own individual username and password. If you do not know the Shield login details, contact your site administrator or IT department.
 
-Navigate to the training environment URL displayed in the slide or whiteboard and type the following username and password into the authentication popup – this is to access the site.
+![](../.gitbook/assets/Unit-1-Shield-Login.png)
 
-Username: refer to the whiteboard
+## Training Environment Details
+In preparation for a training course, you should have received a number of emails providing you with information required throughout the course course. These include:
 
-Password: refer to the whiteboard
+1. The url for your own personal training environment. This will be similar to **https://nginx-yourname-govcms-training.govcms7.amazee.io/user/**
+2. The Shield username and password
+3. Three usernames for your environment \(One for an 'Admin' account, one for a 'Content Author' account and one for a 'Content Approver' account
 
-#### Exercise 1.1: Login to your training site as administrator
+You should also have created and saved **passwords** for each of the above accounts. 
 
-To login to the administrative interface, add **/user** to the end of the link you’ve been given by your trainer. This should bring you to the login page. Notice how although the style and layout of this page is different from the homepage, the “header” and “footer” sections are still the same:
-
-![](../.gitbook/assets/4%20%282%29%20%281%29.png)
-
-Refer to the whiteboard for the login credentials
-
-**Tip:** If you’ve navigated away from the homepage, the link on your browser may differ from the one provided. To get back to the homepage, you can click on the “GovCMS” logo at the top left of the page, or use the “Home” link in the main navigation menu.
-
-After you’ve successfully logged in as an administrator, you’ll be redirected to a page that has your username as the page ‘title’ \(1\), and also shows you a green confirmation message with information about the last time you logged in \(2\):
-
-**Note:** that some elements from the screenshot below may be different, due to permissions settings.
-
-![](../.gitbook/assets/5%20%282%29%20%281%29.png)
-
-Notice the black band running across the top of the page \(3\). This is called the “Admin menu”, and is an indication that you’re currently logged into the site \(as opposed to simply visiting it as an “anonymous” user\). At the top-right of the “Admin toolbar”, you can see the username of the account you’re currently logged in with \(4\).
-
-**Tip:** You might see or hear the Admin menu also referred to as “Administration”, “Admin bar”, “Admin toolbar”, “Navbar”, or simply “Toolbar”.
-
-Next, use either the “GovCMS” logo, or the “Home” menu link to go back to the homepage. You’ll notice that the Admin menu is still there. The Admin menu helps people who have logged into the site \(such as site admins, content authors/reviewers, etc.\) to navigate faster through the various pages of the admin interface. Once logged in, it’s available in the frontend and backend of your GovCMS site.
-
-**Tip:** As mentioned earlier, the regular pages that contain the actual content your site visitors see \(blog/article text, images, etc.\), is often referred to as the “frontend”, while the Admin interface may be referred to as the “backend”.
-
+If you have not received this information or set and saved your passwords, please notify your trainer.

--- a/unit-1-intro-to-the-admin-backend/how-to-login.md
+++ b/unit-1-intro-to-the-admin-backend/how-to-login.md
@@ -2,25 +2,30 @@
 
 {% embed url="https://vimeo.com/469210192/f8b616dd59" %}
 
+## Navigate to Login screen
+
 To get to the **Login screen** of most GovCMS sites, type the site’s URL and add **/user** on the end. \(For many government sites this won't work unless you’re on the internal network.\) For example:
 
 * [https://www.salsadigital.com.au/](https://www.salsadigital.com.au/user)[**user**](https://www.salsadigital.com.au/user)
 
 
 ## Shield protection
-Your environment may be protected by _Shield_ authentication, which means you’ll see a popup window with the username and password fields. You need to enter the Shield **username** and **password** to get to the **Login screen**. 
+Your environment may be protected by _Shield_ authentication, which means you’ll see a popup window with the _Username_ and _Password_ fields. You need to enter the Shield **username** and **password** to get to the **Login screen**. 
 
 **Note** The Shield username and password are distinct from your own individual username and password. If you do not know the Shield login details, contact your site administrator or IT department.
 
 ![](../.gitbook/assets/Unit-1-Shield-Login.png)
 
 ## Training Environment Details
+
+
 In preparation for a training course, you should have received a number of emails providing you with information required throughout the course course. These include:
 
-1. The url for your own personal training environment. This will be similar to **https://nginx-yourname-govcms-training.govcms7.amazee.io/user/**
-2. The Shield username and password
+1. The url for your own personal training environment. This will be similar to **https://nginx-yourname-govcms-training.govcms7.amazee.io/user/**.
+2. The Shield **username** and **password**.
 3. Three usernames for your environment \(One for an 'Admin' account, one for a 'Content Author' account and one for a 'Content Approver' account
 
 You should also have created and saved **passwords** for each of the above accounts. 
 
 If you have not received this information or set and saved your passwords, please notify your trainer.
+


### PR DESCRIPTION
Updated content to make it more generic to non-training participants. Exercises relevant to training course moved to Exercise 1-1 and 1-2. 

To discuss whether to change the salsadigital.com.au/user example. Do we need authorisation to use an agency's site here? The GovCMS site does allow access to the login page so removed that example.